### PR TITLE
Fix #9507

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -246,6 +246,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 /obj/item/weapon/disk/nuclear
 	name = "nuclear authentication disk"
 	desc = "Better keep this safe."
+	icon = 'icons/obj/items.dmi'
 	icon_state = "nucleardisk"
 	item_state = "card-id"
 	w_class = 1.0


### PR DESCRIPTION
Fixes nuke disk missing sprite. Tested
![default](https://cloud.githubusercontent.com/assets/9455174/7665561/546a20fa-fbf8-11e4-9df1-bc3e1f24ab1c.png)
